### PR TITLE
Update js_string.ml

### DIFF
--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -480,7 +480,7 @@ external splitLimited : t -> int -> t array = "split" [@@bs.send.pipe: t]
   splitByRe [%re "/[,;]/"] "has:no:match" = [|"has:no:match"|];;
 ]};
 *)
-external splitByRe : Js_re.t ->  t array = "split" [@@bs.send.pipe: t]
+external splitByRe : Js_re.t ->  t option array = "split" [@@bs.send.pipe: t]
 
 (**
   [splitByReAtMost regex ~limit: n str] splits the given [str] at every occurrence of [regex] and returns an

--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -491,7 +491,7 @@ external splitByRe : Js_re.t ->  t option array = "split" [@@bs.send.pipe: t]
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 3 "one: two: three: four" = [|Some "one"; Some "two"; Some "three"|];;
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 0 "one: two: three: four" = [| |];;
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 8 "one: two: three: four" = [|Some "one"; Some "two"; Some "three"; Some "four"|];;
-  splitByReAtMost [%re "/(#)(:)?/"] "a#b#:c" = [|Some "a"; Some "#"; None|];;
+  splitByReAtMost [%re "/(#)(:)?/"] ~limit:3 "a#b#:c" = [|Some "a"; Some "#"; None|];;
 ]};
 *)
 external splitByReAtMost : Js_re.t -> limit:int ->  t option array = "split" [@@bs.send.pipe: t]

--- a/jscomp/others/js_string.ml
+++ b/jscomp/others/js_string.ml
@@ -476,8 +476,9 @@ external splitLimited : t -> int -> t array = "split" [@@bs.send.pipe: t]
   array of the resulting substrings.
   
 @example {[
-  splitByRe [%re "/\\s*[,;]\\s*/"] "art; bed , cog ;dad" = [|"art"; "bed"; "cog"; "dad"|];;
-  splitByRe [%re "/[,;]/"] "has:no:match" = [|"has:no:match"|];;
+  splitByRe [%re "/\\s*[,;]\\s*/"] "art; bed , cog ;dad" = [|Some "art"; Some "bed"; Some "cog"; Some "dad"|];;
+  splitByRe [%re "/[,;]/"] "has:no:match" = [|Some "has:no:match"|];;
+  splitByRe [%re "/(#)(:)?/"] "a#b#:c" = [|Some "a"; Some "#"; None; Some "b"; Some "#"; Some ":"; Some "c"|];;
 ]};
 *)
 external splitByRe : Js_re.t ->  t option array = "split" [@@bs.send.pipe: t]
@@ -487,12 +488,13 @@ external splitByRe : Js_re.t ->  t option array = "split" [@@bs.send.pipe: t]
   array of the first [n] resulting substrings. If [n] is negative or greater than the number of substrings, the array will contain all the substrings.
   
 @example {[
-  splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 3 "one: two: three: four" = [|"one"; "two"; "three"|];;
+  splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 3 "one: two: three: four" = [|Some "one"; Some "two"; Some "three"|];;
   splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 0 "one: two: three: four" = [| |];;
-  splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 8 "one: two: three: four" = [|"one"; "two"; "three"; "four"|];;
+  splitByReAtMost [%re "/\\s*:\\s*/"] ~limit: 8 "one: two: three: four" = [|Some "one"; Some "two"; Some "three"; Some "four"|];;
+  splitByReAtMost [%re "/(#)(:)?/"] "a#b#:c" = [|Some "a"; Some "#"; None|];;
 ]};
 *)
-external splitByReAtMost : Js_re.t -> limit:int ->  t array = "split" [@@bs.send.pipe: t]
+external splitByReAtMost : Js_re.t -> limit:int ->  t option array = "split" [@@bs.send.pipe: t]
 
 (**
   Deprecated - Please use [splitByReAtMost]

--- a/jscomp/test/js_string_test.ml
+++ b/jscomp/test/js_string_test.ml
@@ -156,10 +156,10 @@ let suites = Mt.[
       Eq([| "foo"; "bar" |], "foo bar baz" |> Js.String.splitAtMost " " ~limit:2)
     );
     "splitByRe", (fun _ ->
-      Eq([| "foo"; "bar"; "baz" |], "foo bar baz" |> Js.String.splitByRe [%re "/\\s/"])
+      Eq([| Some "a"; Some "#"; None; Some "b"; Some "#"; Some ":"; Some "c" |], "a#b#:c" |> Js.String.splitByRe [%re "/(#)(:)?/"])
     );
     "splitByReAtMost", (fun _ ->
-      Eq([| "foo"; "bar" |], "foo bar baz" |> Js.String.splitByReAtMost [%re "/\\s/"] ~limit:2)
+      Eq([| Some "a"; Some "#"; None |], "a#b#:c" |> Js.String.splitByReAtMost [%re "/(#)(:)?/"] ~limit:3)
     );
 
     (* es2015 *)


### PR DESCRIPTION
splitByRe may include undefined in returned array. Fix type of output to match javascript behavior. See https://github.com/BuckleScript/bucklescript/issues/3120